### PR TITLE
fix: should normalize to posix path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,5 +10,8 @@ export function checkIsExclude(
 
   const excludes = Array.isArray(exclude) ? exclude : [exclude];
 
-  return excludes.some((reg) => reg.test(path));
+  // normalize to posix path
+  const normalizedPath = path.replace(/\\/g, '/');
+
+  return excludes.some((reg) => reg.test(normalizedPath));
 }


### PR DESCRIPTION
Should normalize to posix path for RegExp.