### PR TITLE
chore: export checkSyntax as utils

### DIFF
--- a/src/CheckSyntaxPlugin.ts
+++ b/src/CheckSyntaxPlugin.ts
@@ -1,18 +1,7 @@
-import fs from 'node:fs';
 import { resolve } from 'node:path';
 import type { Rspack } from '@rsbuild/core';
-import { parse } from 'acorn';
-import { browserslistToESVersion } from 'browserslist-to-es-version';
-import { generateError } from './generateError.js';
-import { generateHtmlScripts } from './generateHtmlScripts.js';
+import { CheckSyntax } from './checkSyntax.js';
 import { printErrors } from './printErrors.js';
-import type {
-  AcornParseError,
-  CheckSyntaxExclude,
-  CheckSyntaxOptions,
-  ECMASyntaxError,
-  EcmaVersion,
-} from './types.js';
 import { checkIsExclude } from './utils.js';
 
 type Compiler = Rspack.Compiler;
@@ -21,36 +10,10 @@ type Compilation = Rspack.Compilation;
 const HTML_REGEX = /\.html$/;
 export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
 
-export class CheckSyntaxPlugin {
-  errors: ECMASyntaxError[] = [];
-
-  ecmaVersion: EcmaVersion;
-
-  targets: string[];
-
-  rootPath: string;
-
-  exclude: CheckSyntaxExclude | undefined;
-
-  excludeOutput: CheckSyntaxExclude | undefined;
-
-  constructor(
-    options: CheckSyntaxOptions &
-      Required<Pick<CheckSyntaxOptions, 'targets'>> & {
-        rootPath: string;
-      },
-  ) {
-    this.targets = options.targets;
-    this.exclude = options.exclude;
-    this.excludeOutput = options.excludeOutput;
-    this.rootPath = options.rootPath;
-    this.ecmaVersion =
-      options.ecmaVersion || browserslistToESVersion(this.targets);
-  }
-
+export class CheckSyntaxRspackPlugin extends CheckSyntax {
   apply(compiler: Compiler): void {
     compiler.hooks.afterEmit.tapPromise(
-      CheckSyntaxPlugin.name,
+      CheckSyntaxRspackPlugin.name,
       async (compilation: Compilation) => {
         const outputPath = compilation.outputOptions.path || 'dist';
 
@@ -80,43 +43,5 @@ export class CheckSyntaxPlugin {
         printErrors(this.errors, this.ecmaVersion);
       },
     );
-  }
-
-  private async check(filepath: string) {
-    if (HTML_REGEX.test(filepath)) {
-      const htmlScripts = await generateHtmlScripts(filepath);
-      await Promise.all(
-        htmlScripts.map(async (script) => {
-          if (!checkIsExclude(filepath, this.exclude)) {
-            await this.tryParse(filepath, script);
-          }
-        }),
-      );
-    }
-
-    if (JS_REGEX.test(filepath)) {
-      const jsScript = await fs.promises.readFile(filepath, 'utf-8');
-      await this.tryParse(filepath, jsScript);
-    }
-  }
-
-  private async tryParse(filepath: string, code: string) {
-    try {
-      parse(code, { ecmaVersion: this.ecmaVersion });
-    } catch (_: unknown) {
-      const err = _ as AcornParseError;
-
-      const error = await generateError({
-        err,
-        code,
-        filepath,
-        exclude: this.exclude,
-        rootPath: this.rootPath,
-      });
-
-      if (error) {
-        this.errors.push(error);
-      }
-    }
   }
 }

--- a/src/checkSyntax.ts
+++ b/src/checkSyntax.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import { parse } from 'acorn';
+import { browserslistToESVersion } from 'browserslist-to-es-version';
+import { generateError } from './generateError.js';
+import { generateHtmlScripts } from './generateHtmlScripts.js';
+import type {
+  AcornParseError,
+  CheckSyntaxExclude,
+  CheckSyntaxOptions,
+  ECMASyntaxError,
+  EcmaVersion,
+} from './types.js';
+import { checkIsExclude } from './utils.js';
+
+const HTML_REGEX = /\.html$/;
+export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
+
+export class CheckSyntax {
+  errors: ECMASyntaxError[] = [];
+
+  ecmaVersion: EcmaVersion;
+
+  targets: string[];
+
+  rootPath: string;
+
+  exclude: CheckSyntaxExclude | undefined;
+
+  excludeOutput: CheckSyntaxExclude | undefined;
+
+  constructor(
+    options: CheckSyntaxOptions &
+      Required<Pick<CheckSyntaxOptions, 'targets'>> & {
+        rootPath: string;
+      },
+  ) {
+    this.targets = options.targets;
+    this.exclude = options.exclude;
+    this.excludeOutput = options.excludeOutput;
+    this.rootPath = options.rootPath;
+    this.ecmaVersion =
+      options.ecmaVersion || browserslistToESVersion(this.targets);
+  }
+
+  async check(filepath: string, code?: string) {
+    // If the code is provided, no need to read file.
+    if (code) {
+      return await this.tryParse(filepath, code);
+    }
+
+    if (HTML_REGEX.test(filepath)) {
+      const htmlScripts = await generateHtmlScripts(filepath);
+      await Promise.all(
+        htmlScripts.map(async (script) => {
+          if (!checkIsExclude(filepath, this.exclude)) {
+            await this.tryParse(filepath, script);
+          }
+        }),
+      );
+    }
+
+    if (JS_REGEX.test(filepath)) {
+      const jsScript = await fs.promises.readFile(filepath, 'utf-8');
+      await this.tryParse(filepath, jsScript);
+    }
+  }
+
+  async tryParse(filepath: string, code: string) {
+    try {
+      parse(code, { ecmaVersion: this.ecmaVersion });
+    } catch (_: unknown) {
+      const err = _ as AcornParseError;
+
+      const error = await generateError({
+        err,
+        code,
+        filepath,
+        exclude: this.exclude,
+        rootPath: this.rootPath,
+      });
+
+      if (error) {
+        this.errors.push(error);
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { CheckSyntaxPlugin } from './CheckSyntaxPlugin.js';
+import { CheckSyntaxRspackPlugin } from './CheckSyntaxPlugin.js';
 import type { CheckSyntaxOptions } from './types.js';
 
 export type PluginCheckSyntaxOptions = CheckSyntaxOptions;
@@ -22,14 +22,18 @@ export function pluginCheckSyntax(
 
         const targets = options.targets ?? environment.browserslist;
 
-        chain.plugin(CheckSyntaxPlugin.name).use(CheckSyntaxPlugin, [
-          {
-            targets,
-            rootPath,
-            ...(typeof options === 'object' ? options : {}),
-          },
-        ]);
+        chain
+          .plugin(CheckSyntaxRspackPlugin.name)
+          .use(CheckSyntaxRspackPlugin, [
+            {
+              targets,
+              rootPath,
+              ...(typeof options === 'object' ? options : {}),
+            },
+          ]);
       });
     },
   };
 }
+
+export { CheckSyntax } from './checkSyntax.js';


### PR DESCRIPTION
Export checkSyntax as utils, so Rsdoctor can use it to implement syntax checking.