### PR TITLE
feat: add `excludeErrorLogs` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ pluginCheckSyntax({
 });
 ```
 
+### ignoreSyntaxErrorMsg
+
+- **Type:** `('source' | 'output' | 'reason' | 'code')[]`
+- **Default:** `[]`
+
+`ignoreSyntaxErrorMsg` is used to ignore specific syntax error messages during detection. You can pass in one or more syntax error messages to ignore.
+
+- **Example:**
+
+For example, to ignore the reason and code displayed by the terminal
+
+```ts
+pluginCheckSyntax({
+  ignoreSyntaxErrorMsg: ["reason", "code"],
+});
+```
+
 ## Limitations
 
 1. Check Syntax plugin only checks incompatible syntax in the outputs and cannot detect missing polyfills.

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ pluginCheckSyntax({
 - **Type:** `('source' | 'output' | 'reason' | 'code')[]`
 - **Default:** `[]`
 
-`excludeErrorLogs` is used to ignore specific syntax error messages during detection. You can pass in one or more syntax error messages to ignore.
+`excludeErrorLogs` is used to ignore specified syntax error messages after detection. You can pass in one or more error message types to ignore.
 
 - **Example:**
 
-For example, to ignore the reason and code displayed by the terminal
+For example, to ignore the reason and code displayed in the terminal.
 
 ```ts
 pluginCheckSyntax({

--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ pluginCheckSyntax({
 });
 ```
 
-### ignoreSyntaxErrorMsg
+### excludeErrorLogs
 
 - **Type:** `('source' | 'output' | 'reason' | 'code')[]`
 - **Default:** `[]`
 
-`ignoreSyntaxErrorMsg` is used to ignore specific syntax error messages during detection. You can pass in one or more syntax error messages to ignore.
+`excludeErrorLogs` is used to ignore specific syntax error messages during detection. You can pass in one or more syntax error messages to ignore.
 
 - **Example:**
 
@@ -189,7 +189,7 @@ For example, to ignore the reason and code displayed by the terminal
 
 ```ts
 pluginCheckSyntax({
-  ignoreSyntaxErrorMsg: ["reason", "code"],
+  excludeErrorLogs: ["reason", "code"],
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",

--- a/src/CheckSyntaxPlugin.ts
+++ b/src/CheckSyntaxPlugin.ts
@@ -40,7 +40,7 @@ export class CheckSyntaxRspackPlugin extends CheckSyntax {
           }),
         );
 
-        printErrors(this.errors, this.ecmaVersion);
+        printErrors(this.errors, this.ecmaVersion, this.ignoreSyntaxErrorMsg);
       },
     );
   }

--- a/src/CheckSyntaxPlugin.ts
+++ b/src/CheckSyntaxPlugin.ts
@@ -40,7 +40,7 @@ export class CheckSyntaxRspackPlugin extends CheckSyntax {
           }),
         );
 
-        printErrors(this.errors, this.ecmaVersion, this.ignoreSyntaxErrorMsg);
+        printErrors(this.errors, this.ecmaVersion, this.excludeErrorLogs);
       },
     );
   }

--- a/src/checkSyntax.ts
+++ b/src/checkSyntax.ts
@@ -9,6 +9,7 @@ import type {
   CheckSyntaxOptions,
   ECMASyntaxError,
   EcmaVersion,
+  SyntaxErrorKey,
 } from './types.js';
 import { checkIsExclude } from './utils.js';
 
@@ -28,6 +29,8 @@ export class CheckSyntax {
 
   excludeOutput: CheckSyntaxExclude | undefined;
 
+  ignoreSyntaxErrorMsg: SyntaxErrorKey[];
+
   constructor(
     options: CheckSyntaxOptions &
       Required<Pick<CheckSyntaxOptions, 'targets'>> & {
@@ -40,6 +43,7 @@ export class CheckSyntax {
     this.rootPath = options.rootPath;
     this.ecmaVersion =
       options.ecmaVersion || browserslistToESVersion(this.targets);
+    this.ignoreSyntaxErrorMsg = options.ignoreSyntaxErrorMsg || [];
   }
 
   async check(filepath: string, code?: string) {

--- a/src/checkSyntax.ts
+++ b/src/checkSyntax.ts
@@ -29,7 +29,7 @@ export class CheckSyntax {
 
   excludeOutput: CheckSyntaxExclude | undefined;
 
-  ignoreSyntaxErrorMsg: SyntaxErrorKey[];
+  excludeErrorLogs: SyntaxErrorKey[];
 
   constructor(
     options: CheckSyntaxOptions &
@@ -43,7 +43,7 @@ export class CheckSyntax {
     this.rootPath = options.rootPath;
     this.ecmaVersion =
       options.ecmaVersion || browserslistToESVersion(this.targets);
-    this.ignoreSyntaxErrorMsg = options.ignoreSyntaxErrorMsg || [];
+    this.excludeErrorLogs = options.excludeErrorLogs || [];
   }
 
   async check(filepath: string, code?: string) {

--- a/src/printErrors.ts
+++ b/src/printErrors.ts
@@ -1,24 +1,23 @@
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
-import type { ECMASyntaxError, EcmaVersion } from './types.js';
-
-type Error = {
-  source: string;
-  output?: string;
-  reason: string;
-  code: string;
-};
+import type {
+  ECMASyntaxError,
+  EcmaVersion,
+  SyntaxErrorInfo,
+  SyntaxErrorKey,
+} from './types.js';
 
 export function printErrors(
   errors: ECMASyntaxError[],
   ecmaVersion: EcmaVersion,
+  ignoreSyntaxErrorMsg: SyntaxErrorKey[],
 ): void {
   if (errors.length === 0) {
     logger.success('[@rsbuild/plugin-check-syntax] Syntax check passed.');
     return;
   }
 
-  const errs: Error[] = errors.map((error) => ({
+  const errs: SyntaxErrorInfo[] = errors.map((error) => ({
     source: `${error.source.path}:${error.source.line}:${error.source.column}`,
     output: error.output
       ? `${error.output.path}:${error.output.line}:${error.output.column}`
@@ -36,7 +35,7 @@ export function printErrors(
 
   errs.forEach((err, index) => {
     console.log(color.bold(color.red(`  ERROR ${index + 1}`)));
-    printMain(err, longest);
+    printMain(err, longest, ignoreSyntaxErrorMsg);
   });
 
   throw new Error(
@@ -48,7 +47,11 @@ export function printErrors(
   );
 }
 
-function printMain(error: Error, longest: number) {
+function printMain(
+  error: SyntaxErrorInfo,
+  longest: number,
+  ignoreSyntaxErrorMsg: SyntaxErrorKey[],
+) {
   const fillWhiteSpace = (s: string, longest: number) => {
     if (s.length < longest) {
       const rightPadding = ' '.repeat(longest - s.length);
@@ -58,7 +61,7 @@ function printMain(error: Error, longest: number) {
   };
 
   for (const [key, content] of Object.entries(error)) {
-    if (!content) {
+    if (!content || ignoreSyntaxErrorMsg.includes(key as SyntaxErrorKey)) {
       continue;
     }
     const title = color.magenta(`${fillWhiteSpace(`${key}:`, longest + 1)}`);

--- a/src/printErrors.ts
+++ b/src/printErrors.ts
@@ -10,7 +10,7 @@ import type {
 export function printErrors(
   errors: ECMASyntaxError[],
   ecmaVersion: EcmaVersion,
-  ignoreSyntaxErrorMsg: SyntaxErrorKey[],
+  excludeErrorLogs: SyntaxErrorKey[],
 ): void {
   if (errors.length === 0) {
     logger.success('[@rsbuild/plugin-check-syntax] Syntax check passed.');
@@ -35,7 +35,7 @@ export function printErrors(
 
   errs.forEach((err, index) => {
     console.log(color.bold(color.red(`  ERROR ${index + 1}`)));
-    printMain(err, longest, ignoreSyntaxErrorMsg);
+    printMain(err, longest, excludeErrorLogs);
   });
 
   throw new Error(
@@ -50,7 +50,7 @@ export function printErrors(
 function printMain(
   error: SyntaxErrorInfo,
   longest: number,
-  ignoreSyntaxErrorMsg: SyntaxErrorKey[],
+  excludeErrorLogs: SyntaxErrorKey[],
 ) {
   const fillWhiteSpace = (s: string, longest: number) => {
     if (s.length < longest) {
@@ -61,7 +61,7 @@ function printMain(
   };
 
   for (const [key, content] of Object.entries(error)) {
-    if (!content || ignoreSyntaxErrorMsg.includes(key as SyntaxErrorKey)) {
+    if (!content || excludeErrorLogs.includes(key as SyntaxErrorKey)) {
       continue;
     }
     const title = color.magenta(`${fillWhiteSpace(`${key}:`, longest + 1)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type CheckSyntaxOptions = {
    * Used to ignore the information printed out by the terminal when an error is detected
    * You can pass in arrays information you want to ignore
    */
-  ignoreSyntaxErrorMsg?: SyntaxErrorKey[];
+  excludeErrorLogs?: SyntaxErrorKey[];
 };
 
 export interface Location {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,8 @@ export type CheckSyntaxOptions = {
    */
   ecmaVersion?: EcmaVersion;
   /**
-   * Used to ignore the information printed out by the terminal when an error is detected
-   * You can pass in arrays information you want to ignore
+   * Used to ignore specified syntax error messages after detection.
+   * You can pass in one or more error message types to ignore.
    */
   excludeErrorLogs?: SyntaxErrorKey[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export type CheckSyntaxOptions = {
    * The priority of `ecmaVersion` is higher than `targets`.
    */
   ecmaVersion?: EcmaVersion;
+  /**
+   * Used to ignore the information printed out by the terminal when an error is detected
+   * You can pass in arrays information you want to ignore
+   */
+  ignoreSyntaxErrorMsg?: SyntaxErrorKey[];
 };
 
 export interface Location {
@@ -60,3 +65,12 @@ export type AcornParseError = {
   pos: number;
   loc: Location;
 };
+
+export type SyntaxErrorInfo = {
+  source: string;
+  output?: string;
+  reason: string;
+  code: string;
+};
+
+export type SyntaxErrorKey = keyof SyntaxErrorInfo;

--- a/test/esnext/index.test.ts
+++ b/test/esnext/index.test.ts
@@ -117,7 +117,7 @@ test('verifies that the plugin throws an error for optional chaining with ES6 ta
       plugins: [
         pluginCheckSyntax({
           targets: ['chrome >= 53'],
-          ignoreSyntaxErrorMsg: ['source', 'output', 'reason', 'code'],
+          excludeErrorLogs: ['source', 'output', 'reason', 'code'],
         }),
       ],
     },

--- a/test/esnext/index.test.ts
+++ b/test/esnext/index.test.ts
@@ -107,7 +107,7 @@ test('should not throw error when using optional chaining and ecmaVersion is 202
   await expect(rsbuild.build()).resolves.toBeTruthy();
 });
 
-test('verifies that the plugin throws an error for optional chaining with ES6 targets, and that output and reason details are not included in the error message.', async () => {
+test('should allow to exclude the output and reason details from the error message.', async () => {
   const { logs, restore } = proxyConsole();
 
   const rsbuild = await createRsbuild({


### PR DESCRIPTION
Add a new configuration item to the plugin：**ignoreSyntaxErrorMsg**
it is used to ignore specific syntax error messages during detection. You can pass in one or more syntax error messages to ignore.