### PR TITLE
fix: fix package exports file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
       "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": ["dist"],
   "scripts": {


### PR DESCRIPTION
"exports" is configured correctly from dist.
![image](https://github.com/user-attachments/assets/5b1ebef9-e57e-43d7-b9b3-5cf79e0c7b45)

