### PR TITLE
feat: add CheckSyntaxRspackPlugin export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,3 +37,4 @@ export function pluginCheckSyntax(
 }
 
 export { CheckSyntax } from './checkSyntax.js';
+export { CheckSyntaxRspackPlugin } from './CheckSyntaxPlugin.js';


### PR DESCRIPTION
I would like to use this plugin with rspack instead of rsbuild. So I think we need to export the CheckSyntaxRspackPlugin.