### PR TITLE
fix: improve CheckSyntaxRspackPlugin options handling

### DIFF
--- a/src/CheckSyntaxPlugin.ts
+++ b/src/CheckSyntaxPlugin.ts
@@ -12,6 +12,10 @@ export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
 
 export class CheckSyntaxRspackPlugin extends CheckSyntax {
   apply(compiler: Compiler): void {
+    if (compiler.options.context && !this.rootPath) {
+      this.rootPath = compiler.options.context;
+    }
+
     compiler.hooks.afterEmit.tapPromise(
       CheckSyntaxRspackPlugin.name,
       async (compilation: Compilation) => {


### PR DESCRIPTION
Improve CheckSyntaxRspackPlugin options handling, allow `rootPath` to be optional.