### PR TITLE
feat: add excludeErrorMessage option to filter errors by message

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ At this time, the build artifacts can include all syntax supported by ES2020, su
 - **Type:** `RegExp | RegExp[]`
 - **Default:** `undefined`
 
-`exclude` is used to exclude a portion of source files during detection. You can pass in one or more regular expressions to match the paths of source files. Files that match the regular expression will be ignored and will not trigger syntax checking.
+Excludes a portion of source files during detection. You can pass in one or more regular expressions to match the paths of source files. Files that match the regular expression will be ignored and will not trigger syntax checking.
 
 - **Example:**
 
@@ -186,7 +186,7 @@ pluginCheckSyntax({
 - **Type:** `RegExp | RegExp[]`
 - **Default:** `undefined`
 
-`excludeOutput` is used to exclude a portion of output files before detection. You can pass in one or more regular expressions to match the paths of output files. Files that match the regular expression will be ignored and will not trigger syntax checking.
+Excludes a portion of output files before detection. You can pass in one or more regular expressions to match the paths of output files. Files that match the regular expression will be ignored and will not trigger syntax checking.
 
 - **Example:**
 
@@ -198,12 +198,37 @@ pluginCheckSyntax({
 });
 ```
 
+### excludeErrorMessage
+
+- **Type:** `RegExp | RegExp[]`
+- **Default:** `undefined`
+
+Excludes files by error message (reason) before detection. You can pass in one or more regular expressions to match the error messages. Files that match the regular expression will be ignored and will not trigger syntax checking.
+
+- **Example:**
+
+For example, to ignore the error messages when using dynamic import:
+
+```ts
+pluginCheckSyntax({
+  excludeErrorMessage: /'import' and 'export' may only appear at the top level/,
+});
+```
+
+Or ignore the error messages when using `let` or `const` keywords:
+
+```ts
+pluginCheckSyntax({
+  excludeErrorMessage: /The keyword '(let|const)' is reserved/,
+});
+```
+
 ### excludeErrorLogs
 
 - **Type:** `('source' | 'output' | 'reason' | 'code')[]`
 - **Default:** `[]`
 
-`excludeErrorLogs` is used to ignore specified syntax error messages after detection. You can pass in one or more error message types to ignore.
+Ignores specified syntax error messages after detection. You can pass in one or more error message types to ignore.
 
 - **Example:**
 

--- a/src/CheckSyntaxPlugin.ts
+++ b/src/CheckSyntaxPlugin.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import type { Rspack } from '@rsbuild/core';
 import { CheckSyntax } from './checkSyntax.js';
 import { printErrors } from './printErrors.js';
-import { checkIsExclude } from './utils.js';
+import { isPathExcluded } from './utils.js';
 
 type Compiler = Rspack.Compiler;
 type Compilation = Rspack.Compilation;
@@ -29,10 +29,10 @@ export class CheckSyntaxRspackPlugin extends CheckSyntax {
             // remove query from name
             const resourcePath = a.name.split('?')[0];
             const file = resolve(outputPath, resourcePath);
-            if (!checkIsExclude(file, this.excludeOutput)) {
-              return file;
+            if (isPathExcluded(file, this.excludeOutput)) {
+              return '';
             }
-            return '';
+            return file;
           });
 
         const files = emittedAssets.filter(

--- a/src/checkSyntax.ts
+++ b/src/checkSyntax.ts
@@ -11,7 +11,7 @@ import type {
   EcmaVersion,
   SyntaxErrorKey,
 } from './types.js';
-import { checkIsExclude } from './utils.js';
+import { isPathExcluded } from './utils.js';
 
 const HTML_REGEX = /\.html$/;
 export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
@@ -32,9 +32,11 @@ export class CheckSyntax {
 
   rootPath: string;
 
-  exclude: CheckSyntaxExclude | undefined;
+  exclude?: CheckSyntaxExclude;
 
-  excludeOutput: CheckSyntaxExclude | undefined;
+  excludeOutput?: CheckSyntaxExclude;
+
+  excludeErrorMessage?: CheckSyntaxExclude;
 
   excludeErrorLogs: SyntaxErrorKey[];
 
@@ -54,6 +56,7 @@ export class CheckSyntax {
     this.ecmaVersion = ecmaVersion || browserslistToESVersion(targets);
 
     this.exclude = options.exclude;
+    this.excludeErrorMessage = options.excludeErrorMessage;
     this.excludeOutput = options.excludeOutput;
     this.rootPath = options.rootPath || '';
     this.excludeErrorLogs = options.excludeErrorLogs || [];
@@ -69,7 +72,7 @@ export class CheckSyntax {
       const htmlScripts = await generateHtmlScripts(filepath);
       await Promise.all(
         htmlScripts.map(async (script) => {
-          if (!checkIsExclude(filepath, this.exclude)) {
+          if (!isPathExcluded(filepath, this.exclude)) {
             await this.tryParse(filepath, script);
           }
         }),
@@ -93,6 +96,7 @@ export class CheckSyntax {
         code,
         filepath,
         exclude: this.exclude,
+        excludeErrorMessage: this.excludeErrorMessage,
         rootPath: this.rootPath,
       });
 

--- a/src/generateError.ts
+++ b/src/generateError.ts
@@ -6,7 +6,7 @@ import {
   type CheckSyntaxExclude,
   ECMASyntaxError,
 } from './types.js';
-import { checkIsExclude } from './utils.js';
+import { isExcluded, isPathExcluded } from './utils.js';
 
 export function displayCodePointer(code: string, pos: number) {
   const SUB_LEN = 80;
@@ -23,12 +23,14 @@ export async function generateError({
   filepath,
   rootPath,
   exclude,
+  excludeErrorMessage,
 }: {
   err: AcornParseError;
   code: string;
   filepath: string;
   rootPath: string;
   exclude?: CheckSyntaxExclude;
+  excludeErrorMessage?: CheckSyntaxExclude;
 }): Promise<ECMASyntaxError | null> {
   const relativeOutputPath = filepath.replace(rootPath, '');
   let error = await tryGenerateErrorFromSourceMap({
@@ -49,7 +51,11 @@ export async function generateError({
     });
   }
 
-  if (checkIsExclude(error.source.path, exclude)) {
+  if (isPathExcluded(error.source.path, exclude)) {
+    return null;
+  }
+
+  if (isExcluded(error.message, excludeErrorMessage)) {
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,25 +11,30 @@ export type CheckSyntaxOptions = {
    */
   targets?: string[];
   /**
-   * Used to exclude a portion of source files during detection.
+   * Excludes a portion of source files during detection.
    * You can pass in one or more regular expressions to match the paths of source files.
    */
   exclude?: CheckSyntaxExclude;
   /**
-   * Used to exclude files by output path before detection.
+   * Excludes files by output path before detection.
    * You can pass in one or more regular expressions to match the paths of source files.
    */
   excludeOutput?: CheckSyntaxExclude;
+  /**
+   * Excludes files by error message (reason) before detection.
+   * You can pass in one or more regular expressions to match the reasons.
+   */
+  excludeErrorMessage?: CheckSyntaxExclude;
+  /**
+   * Ignores specified syntax error messages after detection.
+   * You can pass in one or more error message types to ignore.
+   */
+  excludeErrorLogs?: SyntaxErrorKey[];
   /**
    * The minimum ECMAScript syntax version that can be used in the build artifact.
    * The priority of `ecmaVersion` is higher than `targets`.
    */
   ecmaVersion?: EcmaVersion;
-  /**
-   * Used to ignore specified syntax error messages after detection.
-   * You can pass in one or more error message types to ignore.
-   */
-  excludeErrorLogs?: SyntaxErrorKey[];
 };
 
 export interface Location {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,18 @@
 import type { CheckSyntaxExclude } from './types.js';
 
-export function checkIsExclude(
-  path: string,
-  exclude?: CheckSyntaxExclude,
-): boolean {
+export const isExcluded = (input: string, exclude?: CheckSyntaxExclude) => {
   if (!exclude) {
     return false;
   }
-
   const excludes = Array.isArray(exclude) ? exclude : [exclude];
+  return excludes.some((reg) => reg.test(input));
+};
 
+export function isPathExcluded(
+  path: string,
+  exclude?: CheckSyntaxExclude,
+): boolean {
   // normalize to posix path
   const normalizedPath = path.replace(/\\/g, '/');
-
-  return excludes.some((reg) => reg.test(normalizedPath));
+  return isExcluded(normalizedPath, exclude);
 }

--- a/test/rsbuild-basic/index.test.ts
+++ b/test/rsbuild-basic/index.test.ts
@@ -124,6 +124,22 @@ test('should not throw error when the output file is excluded', async () => {
   await expect(rsbuild.build()).resolves.toBeTruthy();
 });
 
+test('should not throw error when the error message is excluded', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      ...(await loadConfig({ cwd: __dirname })).content,
+      plugins: [
+        pluginCheckSyntax({
+          excludeErrorMessage: /The keyword '(let|const)' is reserved/,
+        }),
+      ],
+    },
+  });
+
+  await expect(rsbuild.build()).resolves.toBeTruthy();
+});
+
 test('should not throw error when the targets are support es6', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,


### PR DESCRIPTION
## Summary

Add support for excluding syntax errors by matching error messages with regex patterns
