### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-check-syntax",
   "version": "2.0.0",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-check-syntax",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-check-syntax#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-check-syntax/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- add the package homepage pointing to the repository README
- add the package bug tracker URL pointing to GitHub Issues
- leave runtime code, dependencies, exports, and the package version unchanged

The current `@rsbuild/plugin-check-syntax@2.0.0` npm metadata exposes the repository and license, but does not expose `homepage` or `bugs`.

## Validation

- `node -e "const p=require('./package.json'); if(p.homepage!=='https://github.com/rstackjs/rsbuild-plugin-check-syntax#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/rstackjs/rsbuild-plugin-check-syntax/issues') throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2));"`
- `npm view @rsbuild/plugin-check-syntax@2.0.0 name version repository homepage bugs license --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`