### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rslint/core": "^0.6.4",
     "@rspack/cli": "^2.1.2",
     "@rspack/core": "^2.1.2",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.10.6",
     "@types/node": "^24.13.2",
     "prettier": "^3.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@rspack/core':
         specifier: ^2.1.2
         version: 2.1.2(@swc/helpers@0.5.23)
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.10.6
         version: 0.10.6
@@ -401,6 +404,9 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.10.6':
     resolution: {integrity: sha512-nX61dw2Tnxfwy/jGZEuNbh2tzapgaH6Iwj4Aw5d2wxUwxptUL3ddUxFF5M1ZSWoLEVG30VaPg3ITzrSo5sdbTg==}
@@ -949,6 +955,8 @@ snapshots:
       '@rspack/binding': 2.1.2
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.10.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,33 +1,6 @@
 import path from 'node:path';
+export { proxyConsole } from '@rstackjs/test-utils';
 import upath from 'upath';
-
-export const proxyConsole = (
-  types: string[] = ['log', 'warn', 'info', 'error'],
-) => {
-  const logs: string[] = [];
-  const restores: Array<() => void> = [];
-
-  for (const type of types) {
-    const method = console[type];
-
-    restores.push(() => {
-      console[type] = method;
-    });
-
-    console[type] = (log) => {
-      logs.push(log);
-    };
-  }
-
-  return {
-    logs,
-    restore: () => {
-      for (const restore of restores) {
-        restore();
-      }
-    },
-  };
-};
 
 export const normalizeToPosixPath = (p: string | undefined) =>
   upath


### PR DESCRIPTION
This PR replaces the local console capture helper with `proxyConsole` from `@rstackjs/test-utils`, keeping shared test behavior maintained in one package.