### PR TITLE
chore: remove local test helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "rslog": "^2.1.3",
     "simple-git-hooks": "^2.13.1",
     "strip-ansi": "^7.2.0",
-    "typescript": "7.0.2",
-    "upath": "^3.0.7"
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.0 || ^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
-      upath:
-        specifier: ^3.0.7
-        version: 3.0.7
 
 packages:
 
@@ -679,10 +676,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  upath@3.0.7:
-    resolution: {integrity: sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==}
-    engines: {node: '>=20'}
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1155,8 +1148,6 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
-
-  upath@3.0.7: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/test/esnext/index.test.ts
+++ b/test/esnext/index.test.ts
@@ -1,9 +1,10 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
+import { proxyConsole } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import { pluginCheckSyntax } from '../../dist';
-import { normalizeToPosixPath, proxyConsole } from '../helper';
+import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/esnext/index.test.ts
+++ b/test/esnext/index.test.ts
@@ -1,10 +1,9 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
-import { proxyConsole } from '@rstackjs/test-utils';
+import { proxyConsole, toPosixPath } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import { pluginCheckSyntax } from '../../dist';
-import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -34,14 +33,14 @@ test('should throw error when using optional chaining and target is es6 browsers
     logs.find(
       (log) =>
         log.includes('source:') &&
-        normalizeToPosixPath(log).includes('src/test.js'),
+        toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
         log.includes('output:') &&
-        normalizeToPosixPath(log).includes('/dist/static/js/index'),
+        toPosixPath(log).includes('/dist/static/js/index'),
     ),
   ).toBeTruthy();
   expect(
@@ -80,14 +79,14 @@ test('should throw error when using optional chaining and target is fully suppor
     logs.find(
       (log) =>
         log.includes('source:') &&
-        normalizeToPosixPath(log).includes('src/test.js'),
+        toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
         log.includes('output:') &&
-        normalizeToPosixPath(log).includes('/dist/static/js/index'),
+        toPosixPath(log).includes('/dist/static/js/index'),
     ),
   ).toBeTruthy();
   expect(

--- a/test/esnext/index.test.ts
+++ b/test/esnext/index.test.ts
@@ -32,8 +32,7 @@ test('should throw error when using optional chaining and target is es6 browsers
   expect(
     logs.find(
       (log) =>
-        log.includes('source:') &&
-        toPosixPath(log).includes('src/test.js'),
+        log.includes('source:') && toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
@@ -78,8 +77,7 @@ test('should throw error when using optional chaining and target is fully suppor
   expect(
     logs.find(
       (log) =>
-        log.includes('source:') &&
-        toPosixPath(log).includes('src/test.js'),
+        log.includes('source:') && toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,7 +1,0 @@
-import path from 'node:path';
-import upath from 'upath';
-
-export const normalizeToPosixPath = (p: string | undefined) =>
-  upath
-    .normalizeSafe(path.normalize(p || ''))
-    .replace(/^([a-zA-Z]+):/, (_, m: string) => `/${m.toLowerCase()}`);

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-export { proxyConsole } from '@rstackjs/test-utils';
 import upath from 'upath';
 
 export const normalizeToPosixPath = (p: string | undefined) =>

--- a/test/rsbuild-basic/index.test.ts
+++ b/test/rsbuild-basic/index.test.ts
@@ -37,8 +37,7 @@ test('should throw error when exist syntax errors', async () => {
   expect(
     logs.find(
       (log) =>
-        log.includes('source:') &&
-        toPosixPath(log).includes('src/test.js'),
+        log.includes('source:') && toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
@@ -83,8 +82,7 @@ test('should check assets with query correctly', async () => {
   expect(
     logs.find(
       (log) =>
-        log.includes('source:') &&
-        toPosixPath(log).includes('src/test.js'),
+        log.includes('source:') && toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(

--- a/test/rsbuild-basic/index.test.ts
+++ b/test/rsbuild-basic/index.test.ts
@@ -1,10 +1,11 @@
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRsbuild, loadConfig, mergeRsbuildConfig } from '@rsbuild/core';
+import { proxyConsole } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import stripAnsi from 'strip-ansi';
 import { pluginCheckSyntax } from '../../src';
-import { normalizeToPosixPath, proxyConsole } from '../helper';
+import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/rsbuild-basic/index.test.ts
+++ b/test/rsbuild-basic/index.test.ts
@@ -1,11 +1,10 @@
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRsbuild, loadConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import { proxyConsole } from '@rstackjs/test-utils';
+import { proxyConsole, toPosixPath } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import stripAnsi from 'strip-ansi';
 import { pluginCheckSyntax } from '../../src';
-import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -39,14 +38,14 @@ test('should throw error when exist syntax errors', async () => {
     logs.find(
       (log) =>
         log.includes('source:') &&
-        normalizeToPosixPath(log).includes('src/test.js'),
+        toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
         log.includes('output:') &&
-        normalizeToPosixPath(log).includes('/dist/static/js/index'),
+        toPosixPath(log).includes('/dist/static/js/index'),
     ),
   ).toBeTruthy();
   expect(logs.find((log) => log.includes('reason:'))).toBeTruthy();
@@ -85,14 +84,14 @@ test('should check assets with query correctly', async () => {
     logs.find(
       (log) =>
         log.includes('source:') &&
-        normalizeToPosixPath(log).includes('src/test.js'),
+        toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
         log.includes('output:') &&
-        normalizeToPosixPath(log).includes('/dist/static/js/index'),
+        toPosixPath(log).includes('/dist/static/js/index'),
     ),
   ).toBeTruthy();
   expect(logs.find((log) => log.includes('reason:'))).toBeTruthy();

--- a/test/rspack-basic/index.test.ts
+++ b/test/rspack-basic/index.test.ts
@@ -1,10 +1,11 @@
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rspack } from '@rspack/core';
+import { proxyConsole } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import stripAnsi from 'strip-ansi';
 import { CheckSyntaxRspackPlugin } from '../../dist';
-import { normalizeToPosixPath, proxyConsole } from '../helper';
+import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/rspack-basic/index.test.ts
+++ b/test/rspack-basic/index.test.ts
@@ -51,15 +51,13 @@ test('should throw error when exist syntax errors', async () => {
   expect(
     logs.find(
       (log) =>
-        log.includes('source:') &&
-        toPosixPath(log).includes('src/test.js'),
+        log.includes('source:') && toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
-        log.includes('output:') &&
-        toPosixPath(log).includes('/dist/main'),
+        log.includes('output:') && toPosixPath(log).includes('/dist/main'),
     ),
   ).toBeTruthy();
   expect(logs.find((log) => log.includes('reason:'))).toBeTruthy();

--- a/test/rspack-basic/index.test.ts
+++ b/test/rspack-basic/index.test.ts
@@ -1,11 +1,10 @@
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rspack } from '@rspack/core';
-import { proxyConsole } from '@rstackjs/test-utils';
+import { proxyConsole, toPosixPath } from '@rstackjs/test-utils';
 import { expect, test } from '@rstest/core';
 import stripAnsi from 'strip-ansi';
 import { CheckSyntaxRspackPlugin } from '../../dist';
-import { normalizeToPosixPath } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -53,14 +52,14 @@ test('should throw error when exist syntax errors', async () => {
     logs.find(
       (log) =>
         log.includes('source:') &&
-        normalizeToPosixPath(log).includes('src/test.js'),
+        toPosixPath(log).includes('src/test.js'),
     ),
   ).toBeTruthy();
   expect(
     logs.find(
       (log) =>
         log.includes('output:') &&
-        normalizeToPosixPath(log).includes('/dist/main'),
+        toPosixPath(log).includes('/dist/main'),
     ),
   ).toBeTruthy();
   expect(logs.find((log) => log.includes('reason:'))).toBeTruthy();


### PR DESCRIPTION
This PR removes the remaining local test helper in favor of direct imports from `@rstackjs/test-utils`. The tests now use `proxyConsole` and `toPosixPath` from the shared package, allowing the unused `upath` dependency to be removed.