### PR TITLE
refactor: replace picocolors with Node.js styleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib -w",
@@ -34,7 +37,6 @@
     "acorn": "^8.17.0",
     "browserslist-to-es-version": "^1.4.2",
     "htmlparser2": "12.0.0",
-    "picocolors": "^1.1.1",
     "source-map": "^0.7.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       htmlparser2:
         specifier: 12.0.0
         version: 12.0.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       source-map:
         specifier: ^0.7.6
         version: 0.7.6

--- a/src/generateError.ts
+++ b/src/generateError.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import color from 'picocolors';
+import { styleText } from 'node:util';
 import { SourceMapConsumer } from 'source-map';
 import {
   type AcornParseError,
@@ -14,7 +14,7 @@ export function displayCodePointer(code: string, pos: number) {
   const start = Math.max(pos - SUB_LEN / 2, 0);
   const subCode = code.slice(start, start + SUB_LEN);
   const arrowPos = pos - start;
-  const arrowLine = color.yellow('^'.padStart(arrowPos + 11, ' '));
+  const arrowLine = styleText('yellow', '^'.padStart(arrowPos + 11, ' '));
   return `${subCode}\n${arrowLine}`;
 }
 
@@ -73,10 +73,10 @@ export function makeCodeFrame(lines: string[], highlightIndex: number) {
   for (let i = startLine; i < endLine; i++) {
     if (i === highlightIndex) {
       const lineNumber = `> ${i + 1}`.padStart(6, ' ');
-      ret.push(color.yellow(`${lineNumber} | ${lines[i]}`));
+      ret.push(styleText('yellow', `${lineNumber} | ${lines[i]}`));
     } else {
       const lineNumber = ` ${i + 1}`.padStart(6, ' ');
-      ret.push(color.gray(`${lineNumber} | ${lines[i]}`));
+      ret.push(styleText('gray', `${lineNumber} | ${lines[i]}`));
     }
   }
 

--- a/src/printErrors.ts
+++ b/src/printErrors.ts
@@ -1,4 +1,4 @@
-import color from 'picocolors';
+import { styleText } from 'node:util';
 import { logger } from 'rslog';
 
 import type {
@@ -29,13 +29,13 @@ export function printErrors(
 
   const longest = Math.max(...Object.keys(errs[0]).map((err) => err.length));
 
-  const expectedVersion = color.yellow(`ecmaVersion <= ${ecmaVersion}`);
+  const expectedVersion = styleText('yellow', `ecmaVersion <= ${ecmaVersion}`);
   logger.error(
     `[@rsbuild/plugin-check-syntax] Find some syntax that does not match "${expectedVersion}":\n`,
   );
 
   errs.forEach((err, index) => {
-    console.log(color.bold(color.red(`  ERROR ${index + 1}`)));
+    console.log(styleText(['bold', 'red'], `  ERROR ${index + 1}`));
     printMain(err, longest, excludeErrorLogs);
   });
 
@@ -65,7 +65,7 @@ function printMain(
     if (!content || excludeErrorLogs.includes(key as SyntaxErrorKey)) {
       continue;
     }
-    const title = color.magenta(`${fillWhiteSpace(`${key}:`, longest + 1)}`);
+    const title = styleText('magenta', fillWhiteSpace(`${key}:`, longest + 1));
     console.info(`  ${title}  ${content}`);
   }
 

--- a/src/printErrors.ts
+++ b/src/printErrors.ts
@@ -35,7 +35,7 @@ export function printErrors(
   );
 
   errs.forEach((err, index) => {
-    console.log(styleText(['bold', 'red'], `  ERROR ${index + 1}`));
+    console.log(styleText('bold', styleText('red', `  ERROR ${index + 1}`)));
     printMain(err, longest, excludeErrorLogs);
   });
 


### PR DESCRIPTION
## Summary

This PR replaces the direct `picocolors` dependency with Node.js `util.styleText` for terminal styling. It also aligns the package's Node.js engine requirement with `@rsbuild/core` (`^20.19.0 || >=22.12.0`).